### PR TITLE
add methods to Depends to fix R CMD check NOTE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: pandaR
 Title: PANDA algorithm
-Version: 0.99.3
+Version: 0.99.4
 Author: "Dan Schlauch <dschlauch@fas.harvard.edu>"
 Maintainer: Dan Schlauch <dschlauch@fas.harvard.edu>
 Description: Runs PANDA, an algorithm for discovering novel network structure
     by combining information from multiple complimentary data sources.
-Depends: R (>= 3.1.3)
+Depends: R (>= 3.1.3), methods
 Suggests: knitr, igraph
 biocViews: StatisticalMethod, GraphAndNetwork, Microarray, GeneRegulation, NetworkInference, GeneExpression, Transcription, Network
 VignetteBuilder: knitr


### PR DESCRIPTION
**NB** The pull request is incomplete without adding `import(methods)` to the `NAMESPACE` file.

I see you made changes to fix some of the WARNINGs, but there will still be a NOTE about use of the methods package.

`import(methods)` needs to make it into the `NAMESPACE` too, but I don't know where you wanted it added since your `NAMESPACE` is generated by roxygen. Please add it where you deem appropriate.